### PR TITLE
readme: replace sh with bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,14 +53,14 @@ If you would like to show your appreciation for this project,<br>please consider
 You can quickly install minimal functional fox via the command-line by using `curl`:
 
 ```bash
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/mut-ex/minimal-functional-fox/master/install.sh)"
+bash -c "$(curl -fsSL https://raw.githubusercontent.com/mut-ex/minimal-functional-fox/master/install.sh)"
 ```
 
 It is a good idea to inspect the install script for projects you aren't familiar with. To do that, you can download the install script separately, go through it to make sure everything looks OK, then go ahead and run it once you are satisfied:
 
 ```bash
 curl -Lo install.sh https://raw.githubusercontent.com/mut-ex/minimal-functional-fox/master/install.sh
-sh install.sh
+bash install.sh
 ```
 
 **Note:** The install script will create a backup of your existing `userChrome.css`, and `userContent.css` files by renaming them to `userChrome.css~`, and `userContent.css~` respectively in the chrome directory.


### PR DESCRIPTION
sh is not guaranteed to be bash. The install script will fail if run with a non-bash sh, so force it to run with bash.