### PR TITLE
Update userChrome.css for Firefox 113

### DIFF
--- a/userChrome.css
+++ b/userChrome.css
@@ -57,7 +57,7 @@
 
 /* This positions the tabs under the navaigator container */
 #titlebar {
-  -moz-box-ordinal-group: 3 !important;
+  order: 3 !important;
 }
 
 .tabbrowser-tab::after,


### PR DESCRIPTION
The default display model has been changed, rip -moz-box- css items. Now the new modern display: flex is stepping in